### PR TITLE
switched environment variable name

### DIFF
--- a/server-src/app.ts
+++ b/server-src/app.ts
@@ -2,7 +2,7 @@ import * as express from 'express'
 
 const app = express();
 
-const port = process.env.SLACKHUNT_API_SERVER_PORT || 3001
+const port = process.env.PORT || 3001
 
 // tslint:disable-next-line:no-console
 app.listen(port, () => console.log(`api server listening on ${port}`))


### PR DESCRIPTION
the PORT environment variable is used by a lot of hosting environments such as dokku or heroku, so I switched the nonstandard one to it.